### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Publish to Registry
       id: publish_to_registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         GIT_COMMIT: ${{ steps.git_info.outputs.GIT_COMMIT }}
         GIT_TAG: ${{ steps.git_info.outputs.GIT_TAG }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore